### PR TITLE
Adapted to Cabal 1.20

### DIFF
--- a/rounded.cabal
+++ b/rounded.cabal
@@ -10,7 +10,7 @@ maintainer:         Edward A. Kmett <ekmett@gmail.com>
 copyright:          Copyright (C) 2012-2014 Edward A. Kmett, Daniel G. Peebles
 category:           Numeric, Math
 build-type:         Custom
-cabal-version:      >= 1.9.2
+cabal-version:      >= 1.20
 tested-with:        GHC == 7.8.1
 extra-source-files: cbits/mkMpfrDerivedConstants.c, cbits/alloc.c
 description:


### PR DESCRIPTION
I made this change to install rounded on Ubuntu 14.04 with ghc 7.8.3 and cabal 1.20.0.1. It worked even in a sandbox.

I am not sure about the 1.20 lower bound on cabal version. With some CPP one could support old versions of cabal too.
