### PR TITLE
basic build fixup changes

### DIFF
--- a/rounded.cabal
+++ b/rounded.cabal
@@ -57,8 +57,8 @@ library
     Numeric.Rounded.Precision
 
   build-depends:
-    base             >= 4.11    && < 4.16,
-    ghc-prim         >= 0.4     && < 0.8,
+    base             >= 4.11    && < 4.19,
+    ghc-prim         >= 0.4     && < 0.11,
     reflection       >= 2.1.2   && < 2.2,
     hgmp             >= 0.1.1   && < 0.2,
     long-double      >= 0.1     && < 0.2
@@ -68,6 +68,7 @@ library
 
   extra-libraries: mpfr gmp
   pkgconfig-depends: mpfr >= 4.0.0
+                    ,gmp
 
   hs-source-dirs:  src
   c-sources:       cbits/wrappers.c


### PR DESCRIPTION
this is the 

1) basic cleanups needed on build plan side
2) long-double needs a bounds relaxation too @claudeha 
3) i'm not quite sure why, but gmp needs to be explicitly listed as a pkg-config dep with `cabal-install` version `3.10`, and 

maybe @ryanglscott has thoughts on some of these version or cabal things